### PR TITLE
Support kubernetes datastore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ dist/gobgp:
 dist/calico-bgp-daemon: $(SRC_FILES) vendor
 	mkdir -p $(@D)
 	go build -v -o dist/calico-bgp-daemon \
-	-ldflags "-X main.VERSION=$(GOBGPD_VERSION) -s -w" main.go ipam.go
+	-ldflags "-X main.VERSION=$(GOBGPD_VERSION) -s -w" main.go ipam.go k8s.go
 
 build-containerized: clean vendor dist/gobgp
 	mkdir -p dist

--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,11 @@
-hash: 75e3ff856f410b7511a49591c9692cb2c1f3e84e8f75bb8f05822df266984a59
-updated: 2017-08-03T11:14:40.839484276-07:00
+hash: a11c390e4326539e32a54ef6e71fbe5fae8adf7f6a836bb4a8ae4b81dc13efd0
+updated: 2017-10-04T00:59:10.714193307Z
 imports:
+- name: cloud.google.com/go
+  version: 3b1ae45394a234c385be014e9a488f2bb6eef821
+  subpackages:
+  - compute/metadata
+  - internal
 - name: github.com/armon/go-radix
   version: 4239b77079c7b5d1243b7b4736304ce8ddb6f0f2
 - name: github.com/coreos/etcd
@@ -12,6 +17,14 @@ imports:
   - pkg/tlsutil
   - pkg/transport
   - pkg/types
+- name: github.com/coreos/go-oidc
+  version: be73733bb8cc830d0205609b95d125215f8e9c70
+  subpackages:
+  - http
+  - jose
+  - key
+  - oauth2
+  - oidc
 - name: github.com/coreos/go-systemd
   version: 48702e0da86bd25e76cfef347e2adeb434a0d0a6
   subpackages:
@@ -22,8 +35,11 @@ imports:
   version: 3ac0863d7acf3bc44daf49afef8919af12f704ef
   subpackages:
   - capnslog
+  - health
+  - httputil
+  - timeutil
 - name: github.com/davecgh/go-spew
-  version: 346938d642f2ec3594ed81d874461961cd0faa76
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
 - name: github.com/docker/distribution
@@ -87,6 +103,8 @@ imports:
   - client/v2
   - models
   - pkg/escape
+- name: github.com/jonboulle/clockwork
+  version: 2eee05ed794112d45db504eb05aa693efd2b8b09
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/kelseyhightower/envconfig
@@ -126,7 +144,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 93f9e49214a678551648eb9c28ce57bc286a3169
+  version: 09904c3edaef8e571a38cba4195d555537b8fcc2
   subpackages:
   - lib/api
   - lib/api/unversioned
@@ -135,8 +153,8 @@ imports:
   - lib/backend/compat
   - lib/backend/etcd
   - lib/backend/k8s
+  - lib/backend/k8s/custom
   - lib/backend/k8s/resources
-  - lib/backend/k8s/thirdparty
   - lib/backend/model
   - lib/client
   - lib/converter
@@ -191,12 +209,20 @@ imports:
   version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
   subpackages:
   - context
+  - context/ctxhttp
   - http2
   - http2/hpack
   - idna
   - internal/timeseries
   - lex/httplex
   - trace
+- name: golang.org/x/oauth2
+  version: 3c3a985cb79f52a3190fbc056984415ca6763d01
+  subpackages:
+  - google
+  - internal
+  - jws
+  - jwt
 - name: golang.org/x/sys
   version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
   subpackages:
@@ -215,6 +241,18 @@ imports:
   - unicode/bidi
   - unicode/norm
   - width
+- name: google.golang.org/appengine
+  version: 4f7eeb5305a4ba1966344836ba4af9996b7b4e05
+  subpackages:
+  - internal
+  - internal/app_identity
+  - internal/base
+  - internal/datastore
+  - internal/log
+  - internal/modules
+  - internal/remote_api
+  - internal/urlfetch
+  - urlfetch
 - name: google.golang.org/grpc
   version: 777daa17ff9b5daef1cfdf915088a2ada3332bf0
   subpackages:
@@ -305,10 +343,7 @@ imports:
   - kubernetes/typed/storage/v1
   - kubernetes/typed/storage/v1beta1
   - pkg/api
-  - pkg/api/errors
   - pkg/api/install
-  - pkg/api/meta
-  - pkg/api/unversioned
   - pkg/api/v1
   - pkg/apis/apps
   - pkg/apis/apps/install
@@ -349,17 +384,15 @@ imports:
   - pkg/apis/storage/install
   - pkg/apis/storage/v1
   - pkg/apis/storage/v1beta1
-  - pkg/fields
-  - pkg/runtime
-  - pkg/runtime/schema
-  - pkg/runtime/serializer
   - pkg/util
   - pkg/util/parsers
-  - pkg/util/wait
   - pkg/version
-  - pkg/watch
+  - plugin/pkg/client/auth
+  - plugin/pkg/client/auth/gcp
+  - plugin/pkg/client/auth/oidc
   - rest
   - rest/watch
+  - third_party/forked/golang/template
   - tools/auth
   - tools/cache
   - tools/clientcmd
@@ -373,4 +406,5 @@ imports:
   - util/flowcontrol
   - util/homedir
   - util/integer
+  - util/jsonpath
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -16,7 +16,7 @@ import:
   - server
   - table
 - package: github.com/projectcalico/libcalico-go
-  version: 93f9e49214a678551648eb9c28ce57bc286a3169
+  version: v1.6.1
   subpackages:
   - lib/api
   - lib/client
@@ -27,3 +27,5 @@ import:
   subpackages:
   - context
 - package: gopkg.in/tomb.v2
+- package: k8s.io/client-go
+  version: 4a3ab2f5be5177366f8206fd79ce55ca80e417fa

--- a/ipam.go
+++ b/ipam.go
@@ -18,6 +18,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 
@@ -73,7 +74,11 @@ func (c *ipamCache) match(prefix string) *ipPool {
 // update updates the internal map with IPAM updates when the update
 // is new addtion to the map or changes the existing item, it calls
 // updateHandler
-func (c *ipamCache) update(node *etcd.Node, del bool) error {
+func (c *ipamCache) update(nodeEtcd interface{}, del bool) error {
+	if reflect.TypeOf(nodeEtcd) != reflect.TypeOf(&etcd.Node{}) {
+		log.Panicf("unknown parameter type: %s", reflect.TypeOf(nodeEtcd))
+	}
+	node := nodeEtcd.(*etcd.Node)
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	log.Printf("update ipam cache: %s, %v, %t", node.Key, node.Value, del)

--- a/k8s.go
+++ b/k8s.go
@@ -1,0 +1,644 @@
+// Copyright (c) 2013 Kelsey Hightower
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// Copyright (C) 2017 VA Linux Systems Japan K.K.
+// Copyright (C) 2017 Fumihiko Kakuma <kakuma at valinux co jp>
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+//
+// NOTE:
+//    Some codes of this file are from backends/k8s/client.go on
+//    https://github.com/projectcalico/confd repository.
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	backendapi "github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/compat"
+	"github.com/projectcalico/libcalico-go/lib/backend/k8s/resources"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/numorstring"
+
+	svbgpconfig "github.com/osrg/gobgp/config"
+	svbgptable "github.com/osrg/gobgp/table"
+	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	kapiv1 "k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	Act_add  = "add"
+	Act_upd  = "upd"
+	Act_del  = "del"
+	Act_same = "same"
+)
+
+type ActionList struct {
+	Add  []string
+	Upd  []string
+	Del  []string
+	Same []string
+}
+
+func CompareMap(lasts map[string]string, currs map[string]string) ActionList {
+	act := ActionList{}
+	for key, last := range lasts {
+		if cur, ok := currs[key]; ok == false {
+			act.Del = append(act.Del, key)
+		} else if last != cur {
+			act.Upd = append(act.Upd, key)
+		} else {
+			act.Same = append(act.Same, key)
+		}
+	}
+	for key, _ := range currs {
+		if _, ok := lasts[key]; ok == false {
+			act.Add = append(act.Add, key)
+		}
+	}
+	return act
+}
+
+// populateFromKVPairs populates the vars KV map from the supplied set of
+// KVPairs.  This uses the libcalico-go compat module and serialization functions
+// to write out the KVPairs in etcdv2 format.  This works in conjunction with the
+// etcdVarClient defined below which provides a "mock" etcd backend which actually
+// just writes out data to the vars map.
+func populateFromKVPairs(kvps []*model.KVPair, vars map[string]string) {
+	// Create a etcdVarClient to write the KVP results in the vars map, using the
+	// compat adaptor to write the values in etcdv2 format.
+	client := compat.NewAdaptor(&etcdVarClient{vars: vars})
+	for _, kvp := range kvps {
+		if _, err := client.Apply(kvp); err != nil {
+			log.Error("Failed to convert k8s data to etcdv2 equivalent: %s = %s", kvp.Key, kvp.Value)
+		}
+	}
+}
+
+type IntervalProcessor struct {
+	interval int
+	k8scli   *k8sClient
+	ipam     *ipamCacheK8s
+}
+
+func (p *IntervalProcessor) IntervalLoop() error {
+	if err := p.k8scli.updatePrefix(); err != nil {
+		return err
+	}
+	if err := p.k8scli.initialNeighborConfigSetting(); err != nil {
+		return err
+	}
+	ippool, err := p.ipam.getIPPools()
+	if err != nil {
+		return err
+	}
+	p.ipam.lastIPPool = ippool
+	for {
+		log.Debug("polling")
+		p.ipam.sync()
+		p.k8scli.checkBGPConfig()
+		time.Sleep(time.Duration(p.interval) * time.Second)
+	}
+}
+
+type k8sClient struct {
+	node              string
+	server            *Server
+	k8scli            *kubernetes.Clientset
+	nodeBgpPeerClient resources.K8sNodeResourceClient
+	nodeBgpCfgClient  resources.K8sNodeResourceClient
+	lastBgpconfig     map[string]string
+}
+
+// create new Kubernetes client
+func NewK8sClient(s *Server) (*k8sClient, error) {
+	loadingRules := clientcmd.ClientConfigLoadingRules{}
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&loadingRules, &clientcmd.ConfigOverrides{}).ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the clientset
+	cs, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return &k8sClient{
+		node:              os.Getenv(NODENAME),
+		server:            s,
+		k8scli:            cs,
+		nodeBgpPeerClient: resources.NewNodeBGPPeerClient(cs),
+		nodeBgpCfgClient:  resources.NewNodeBGPConfigClient(cs),
+	}, nil
+}
+
+func (c *k8sClient) updatePrefix() error {
+	var paths []*svbgptable.Path
+	node, err := c.k8scli.Nodes().Get(c.node, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	cidr := node.Spec.PodCIDR
+	path, err := c.server.makePath(cidr, false)
+	log.Debugf("Set prefix: %#v", path)
+	paths = append(paths, path)
+	if err = c.server.updatePrefixSet(paths); err != nil {
+		return err
+	}
+	if _, err := c.server.bgpServer.AddPath("", paths); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *k8sClient) initialNeighborConfigSetting() error {
+	bgpconfig, err := c.getBGPConfig()
+	if err != nil {
+		return err
+	}
+	c.lastBgpconfig = bgpconfig
+	neighborConfigs, err := c.getNeighborConfigs(c.lastBgpconfig)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighborConfigs {
+		if err = c.server.bgpServer.AddNeighbor(n); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// getNeighborConfigs returns the complete list of BGP neighbor configuration
+// which the node should peer.
+func (c *k8sClient) getNeighborConfigs(bgpconfig map[string]string) ([]*svbgpconfig.Neighbor, error) {
+	var neighbors []*svbgpconfig.Neighbor
+	if mesh, ok := bgpconfig[GlobalNodeMesh]; ok == false {
+		return nil, errors.New("mesh data not found")
+	} else if mesh == `{"enabled":true}` {
+		log.Debug("enable mesh")
+		ns, err := c.server.getMeshNeighborConfigs()
+		if err != nil {
+			return nil, err
+		}
+		neighbors = append(neighbors, ns...)
+	}
+	// --- Global peers ---
+	if ns, err := c.server.getGlobalNeighborConfigs(); err != nil {
+		return nil, err
+	} else {
+		neighbors = append(neighbors, ns...)
+	}
+	// --- Node-specific peers ---
+	if ns, err := c.server.getNodeSpecificNeighborConfigs(); err != nil {
+		return nil, err
+	} else {
+		neighbors = append(neighbors, ns...)
+	}
+	log.Debugf("neighbors=%s", neighbors)
+	return neighbors, nil
+}
+
+// checkBGPConfig checks the difference from the last BGP config information.
+// But in a case of the following changing, return error.
+//   /calico/bgp/v1/host/$NODENAME or /calico/global/as_num
+func (c *k8sClient) checkBGPConfig() error {
+	curBgpconfig, err := c.getBGPConfig()
+	if err != nil {
+		return nil
+	}
+	log.Debugf("checkBGPConfig lastBgpconfig: %s", c.lastBgpconfig)
+	if reflect.DeepEqual(c.lastBgpconfig, curBgpconfig) {
+		return nil
+	}
+	act := CompareMap(c.lastBgpconfig, curBgpconfig)
+	log.Debugf("checkBGPConfig action list: %#v", act)
+	for _, key := range act.Add {
+		if err := c.updateBGPConfig(Act_add, key, curBgpconfig); err != nil {
+			return err
+		}
+	}
+	for _, key := range act.Upd {
+		if err := c.updateBGPConfig(Act_upd, key, curBgpconfig); err != nil {
+			return err
+		}
+	}
+	for _, key := range act.Del {
+		if err := c.updateBGPConfig(Act_del, key, c.lastBgpconfig); err != nil {
+			return err
+		}
+	}
+	c.lastBgpconfig = curBgpconfig
+	return nil
+}
+
+func (c *k8sClient) updateBGPConfig(action string, key string, bgpconfig map[string]string) error {
+
+	handleNonMeshNeighbor := func(neighborType string, peer string) error {
+		n, err := getNeighborConfigFromPeer(peer, neighborType)
+		if err != nil {
+			return err
+		}
+		switch action {
+		case Act_del:
+			return c.server.bgpServer.DeleteNeighbor(n)
+		case Act_add, Act_upd:
+			return c.server.bgpServer.AddNeighbor(n)
+		}
+		log.Printf("Unhandled action: %s", action)
+		return nil
+	}
+
+	var err error = nil
+	value := bgpconfig[key]
+	switch {
+	case strings.HasPrefix(key, fmt.Sprintf("%s/peer_", GlobalBGP)):
+		err = handleNonMeshNeighbor("global", value)
+	case strings.HasPrefix(key, fmt.Sprintf("%s/%s/peer_", AllNodes, c.node)):
+		err = handleNonMeshNeighbor("node", value)
+	case strings.HasPrefix(key, fmt.Sprintf("%s/%s", AllNodes, c.node)):
+		log.Println("Local host config update. Restart")
+		os.Exit(1)
+	case strings.HasPrefix(key, AllNodes):
+		elems := strings.Split(key, "/")
+		if len(elems) < 4 {
+			log.Printf("Unhandled key: %s", key)
+			return nil
+		}
+		deleteNeighbor := func(address string) error {
+			if address == "" {
+				return nil
+			}
+			n := &svbgpconfig.Neighbor{
+				Config: svbgpconfig.NeighborConfig{
+					NeighborAddress: address,
+				},
+			}
+			return c.server.bgpServer.DeleteNeighbor(n)
+		}
+		host := elems[len(elems)-2]
+		switch elems[len(elems)-1] {
+		case "ip_addr_v4", "ip_addr_v6":
+			switch action {
+			case Act_del:
+				if err = deleteNeighbor(value); err != nil {
+					return err
+				}
+			case Act_add, Act_upd:
+				if action == Act_upd {
+					if err = deleteNeighbor(c.lastBgpconfig[key]); err != nil {
+						return err
+					}
+				}
+				if value == "" {
+					return nil
+				}
+				asn, err := c.server.getPeerASN(host)
+				if err != nil {
+					return err
+				}
+				n := &svbgpconfig.Neighbor{
+					Config: svbgpconfig.NeighborConfig{
+						NeighborAddress: value,
+						PeerAs:          uint32(asn),
+						Description:     fmt.Sprintf("Mesh_%s", underscore(value)),
+					},
+				}
+				if err = c.server.bgpServer.AddNeighbor(n); err != nil {
+					return err
+				}
+			}
+		case "as_num":
+			var asn numorstring.ASNumber
+			if action == Act_upd {
+				asn, err = numorstring.ASNumberFromString(value)
+				if err != nil {
+					return err
+				}
+			} else {
+				asn, err = c.server.getNodeASN()
+				if err != nil {
+					return err
+				}
+			}
+			for _, version := range []string{"v4", "v6"} {
+				ip, ok := bgpconfig[fmt.Sprintf("%s/%s/ip_addr_%s", AllNodes, host, version)]
+				if ok == false {
+					return errors.New("ip address data not found")
+				}
+				if ip == "" {
+					continue
+				}
+				if err = deleteNeighbor(ip); err != nil {
+					return err
+				}
+				n := &svbgpconfig.Neighbor{
+					Config: svbgpconfig.NeighborConfig{
+						NeighborAddress: value,
+						PeerAs:          uint32(asn),
+						Description:     fmt.Sprintf("Mesh_%s", underscore(value)),
+					},
+				}
+				if err = c.server.bgpServer.AddNeighbor(n); err != nil {
+					return err
+				}
+			}
+		default:
+			log.Printf("Unhandled key: %s", key)
+		}
+	case strings.HasPrefix(key, fmt.Sprintf("%s/as_num", GlobalBGP)):
+		log.Println("Global AS number update. Restart")
+		os.Exit(1)
+	case strings.HasPrefix(key, fmt.Sprintf("%s/node_mesh", GlobalBGP)):
+		mesh, err := c.server.isMeshMode()
+		if err != nil {
+			return err
+		}
+		ns, err := c.server.getMeshNeighborConfigs()
+		if err != nil {
+			return err
+		}
+		for _, n := range ns {
+			if mesh {
+				err = c.server.bgpServer.AddNeighbor(n)
+			} else {
+				err = c.server.bgpServer.DeleteNeighbor(n)
+			}
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return err
+}
+
+func (c *k8sClient) getBGPConfig() (map[string]string, error) {
+	var bgpconfig = make(map[string]string)
+
+	calicoK8sCl := c.server.client.Backend
+
+	// Set default values for fields that we always expect to have.
+	bgpconfig[GlobalLogging] = "info"
+	bgpconfig[GlobalASN] = "64512"
+	bgpconfig[GlobalNodeMesh] = `{"enabled":true}`
+
+	// Global data consists of both global config and global peers.
+	kvps, err := calicoK8sCl.List(model.GlobalBGPConfigListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	populateFromKVPairs(kvps, bgpconfig)
+
+	kvps, err = calicoK8sCl.List(model.GlobalBGPPeerListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	populateFromKVPairs(kvps, bgpconfig)
+
+	nodes, err := c.k8scli.Nodes().List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for _, kNode := range nodes.Items {
+		err := c.populateNodeDetails(&kNode, bgpconfig)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	log.Debugf("Get bgp config: %s", bgpconfig)
+	return bgpconfig, err
+}
+
+// populateNodeDetails populates the given kvps map with values we track from the k8s Node object.
+func (c *k8sClient) populateNodeDetails(kNode *kapiv1.Node, vars map[string]string) error {
+	kvps := []*model.KVPair{}
+
+	// Start with the main Node configuration
+	cNode, err := resources.K8sNodeToCalico(kNode)
+	if err != nil {
+		log.Error("Failed to parse k8s Node into Calico Node")
+		return err
+	}
+	kvps = append(kvps, cNode)
+
+	// Add per-node BGP config (each of the per-node resource clients also implements
+	// the CustomK8sNodeResourceList interface, used to extract per-node resources from
+	// the Node resource.
+	if cfg, err := c.nodeBgpCfgClient.ExtractResourcesFromNode(kNode); err != nil {
+		log.Error("Failed to parse BGP configs from node resource - skip config data")
+	} else {
+		kvps = append(kvps, cfg...)
+	}
+
+	if peers, err := c.nodeBgpPeerClient.ExtractResourcesFromNode(kNode); err != nil {
+		log.Error("Failed to parse BGP peers from node resource - skip config data")
+	} else {
+		kvps = append(kvps, peers...)
+	}
+
+	// Populate the vars map from the KVPairs.
+	populateFromKVPairs(kvps, vars)
+
+	return nil
+}
+
+// etcdVarClient implements the libcalico-go backend api.Client interface.  It is used to
+// write the KVPairs retrieved from the Kubernetes datastore driver into the KV map
+// using etcdv2 naming scheme.
+type etcdVarClient struct {
+	vars map[string]string
+}
+
+func (c *etcdVarClient) Create(kvp *model.KVPair) (*model.KVPair, error) {
+	log.Fatal("Create should not be invoked")
+	return nil, nil
+}
+
+func (c *etcdVarClient) Update(kvp *model.KVPair) (*model.KVPair, error) {
+	log.Fatal("Update should not be invoked")
+	return nil, nil
+}
+
+func (c *etcdVarClient) Apply(kvp *model.KVPair) (*model.KVPair, error) {
+	path, err := model.KeyToDefaultPath(kvp.Key)
+	if err != nil {
+		log.Error("Unable to create path from Key: %s", kvp.Key)
+		return nil, err
+	}
+	value, err := model.SerializeValue(kvp)
+	if err != nil {
+		log.Error("Unable to serialize value: %s", kvp.Key)
+		return nil, err
+	}
+	c.vars[path] = string(value)
+	return kvp, nil
+}
+
+func (c *etcdVarClient) Delete(kvp *model.KVPair) error {
+	// Delete may be invoked as part of the Apply processing for  multi-key resource.
+	// However, since we start from an empty map each time, we never need to delete entries,
+	// so just ignore this request.
+	log.Debug("Delete ignored")
+	return nil
+}
+
+func (c *etcdVarClient) Get(key model.Key) (*model.KVPair, error) {
+	log.Fatal("Get should not be invoked")
+	return nil, nil
+}
+
+func (c *etcdVarClient) List(list model.ListInterface) ([]*model.KVPair, error) {
+	log.Fatal("List should not be invoked")
+	return nil, nil
+}
+
+func (c *etcdVarClient) Syncer(callbacks backendapi.SyncerCallbacks) backendapi.Syncer {
+	log.Fatal("Syncer should not be invoked")
+	return nil
+}
+
+func (c *etcdVarClient) EnsureInitialized() error {
+	log.Fatal("EnsureIntialized should not be invoked")
+	return nil
+}
+
+func (c *etcdVarClient) EnsureCalicoNodeInitialized(node string) error {
+	log.Fatal("EnsureCalicoNodeInitialized should not be invoked")
+	return nil
+}
+
+type ipamCacheK8s struct {
+	mu            sync.RWMutex
+	m             map[string]*ipPool
+	server        *Server
+	updateHandler func(*ipPool) error
+	lastIPPool    map[string]string
+}
+
+// create new IPAM cache
+func NewIPAMCacheK8s(s *Server, updateHandler func(*ipPool) error) *ipamCacheK8s {
+	return &ipamCacheK8s{
+		m:             make(map[string]*ipPool),
+		server:        s,
+		updateHandler: updateHandler,
+	}
+}
+
+// match checks whether we have an IP pool which contains the given prefix.
+// If we have, it returns the pool.
+func (c *ipamCacheK8s) match(prefix string) *ipPool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for _, p := range c.m {
+		if p.contain(prefix) {
+			return p
+		}
+	}
+	return nil
+}
+
+// update updates the internal map with IPAM updates when the update
+// is new addtion to the map or changes the existing item, it calls
+// updateHandler
+func (c *ipamCacheK8s) update(ipPoolData interface{}, del bool) error {
+	if reflect.TypeOf(ipPoolData) != reflect.TypeOf("") {
+		log.Panicf("unknown parameter type: %s", reflect.TypeOf(ipPoolData))
+	}
+	ippool := ipPoolData.(string)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	log.Printf("update ipam cache: %s %t", ippool, del)
+	if ippool == "" {
+		return nil
+	}
+	p := &ipPool{}
+	if err := json.Unmarshal([]byte(ippool), p); err != nil {
+		return err
+	}
+	if p.CIDR == "" {
+		return fmt.Errorf("empty cidr: %s", ippool)
+	}
+	q := c.m[p.CIDR]
+	if del {
+		delete(c.m, p.CIDR)
+		return nil
+	} else if p.equal(q) {
+		return nil
+	}
+
+	c.m[p.CIDR] = p
+
+	if c.updateHandler != nil {
+		return c.updateHandler(p)
+	}
+	return nil
+}
+
+func (c *ipamCacheK8s) getIPPools() (map[string]string, error) {
+	var ippools = make(map[string]string)
+	kvps, err := c.server.client.Backend.List(model.IPPoolListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	populateFromKVPairs(kvps, ippools)
+	log.Debugf("Get ip pool: %s", ippools)
+	return ippools, nil
+}
+
+// sync synchronizes the contents under /calico/v1/ipam
+func (c *ipamCacheK8s) sync() error {
+	currIPPool, err := c.getIPPools()
+	if err != nil {
+		return err
+	}
+	log.Debugf("sync lastIPPool: %s", c.lastIPPool)
+	if reflect.DeepEqual(c.lastIPPool, currIPPool) {
+		return nil
+	}
+	act := CompareMap(c.lastIPPool, currIPPool)
+	log.Debugf("sync action list: %#v", act)
+	for _, key := range append(act.Add, act.Upd...) {
+		if err := c.update(currIPPool[key], false); err != nil {
+			return err
+		}
+	}
+	for _, key := range act.Del {
+		if err := c.update(c.lastIPPool[key], true); err != nil {
+			return err
+		}
+	}
+	c.lastIPPool = currIPPool
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -44,12 +45,21 @@ import (
 
 const (
 	NODENAME      = "NODENAME"
+	INTERVAL      = "BGPD_INTERVAL"
 	AS            = "AS"
 	CALICO_PREFIX = "/calico"
 	CALICO_BGP    = CALICO_PREFIX + "/bgp/v1"
 	CALICO_AGGR   = CALICO_PREFIX + "/ipam/v2/host"
 	CALICO_IPAM   = CALICO_PREFIX + "/v1/ipam"
 
+	IpPoolV4       = CALICO_IPAM + "/v4/pool"
+	GlobalBGP      = CALICO_BGP + "/global"
+	GlobalASN      = GlobalBGP + "/as_num"
+	GlobalNodeMesh = GlobalBGP + "/node_mesh"
+	GlobalLogging  = GlobalBGP + "/loglevel"
+	AllNodes       = CALICO_BGP + "/host"
+
+	PollingInterval    = 300
 	defaultDialTimeout = 30 * time.Second
 
 	aggregatedPrefixSetName = "aggregated"
@@ -57,6 +67,12 @@ const (
 
 	RTPROT_GOBGP = 0x11
 )
+
+type IpamCache interface {
+	match(string) *ipPool
+	update(interface{}, bool) error
+	sync() error
+}
 
 // VERSION is filled out during the build process (using git describe output)
 var VERSION string
@@ -142,11 +158,13 @@ func cleanUpRoutes() error {
 type Server struct {
 	t         tomb.Tomb
 	bgpServer *bgpserver.BgpServer
+	datastore calicoapi.DatastoreType
 	client    *calicocli.Client
 	etcd      etcd.KeysAPI
+	process   *IntervalProcessor
 	ipv4      net.IP
 	ipv6      net.IP
-	ipam      *ipamCache
+	ipam      IpamCache
 	reloadCh  chan []*bgptable.Path
 }
 
@@ -155,17 +173,6 @@ func NewServer() (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	etcdConfig, err := getEtcdConfig(config)
-	if err != nil {
-		return nil, err
-	}
-
-	cli, err := etcd.New(etcdConfig)
-	if err != nil {
-		return nil, err
-	}
-	etcdCli := etcd.NewKeysAPI(cli)
 
 	calicoCli, err := calicocli.New(*config)
 	if err != nil {
@@ -190,14 +197,48 @@ func NewServer() (*Server, error) {
 
 	bgpServer := bgpserver.NewBgpServer()
 
-	return &Server{
+	datastoreType := config.Spec.DatastoreType
+	server := Server{
 		bgpServer: bgpServer,
+		datastore: datastoreType,
 		client:    calicoCli,
-		etcd:      etcdCli,
 		ipv4:      ipv4,
 		ipv6:      ipv6,
 		reloadCh:  make(chan []*bgptable.Path),
-	}, nil
+	}
+
+	if datastoreType == calicoapi.EtcdV2 {
+		etcdConfig, err := getEtcdConfig(config)
+		if err != nil {
+			return nil, err
+		}
+		cli, err := etcd.New(etcdConfig)
+		if err != nil {
+			return nil, err
+		}
+		server.etcd = etcd.NewKeysAPI(cli)
+	} else if datastoreType == calicoapi.Kubernetes {
+		k8s, err := NewK8sClient(&server)
+		if err != nil {
+			return nil, err
+		}
+		ipam := NewIPAMCacheK8s(&server, server.ipamUpdateHandler)
+		server.ipam = ipam
+		interval := PollingInterval
+		i, err := strconv.Atoi(os.Getenv(INTERVAL))
+		if err == nil {
+			interval = i
+		}
+		server.process = &IntervalProcessor{
+			interval: interval,
+			k8scli:   k8s,
+			ipam:     ipam,
+		}
+	} else {
+		log.Fatal("unsupported datastore type: ", datastoreType)
+	}
+
+	return &server, nil
 }
 
 func (s *Server) Serve() {
@@ -222,15 +263,20 @@ func (s *Server) Serve() {
 		log.Fatal(err)
 	}
 
-	s.ipam = newIPAMCache(s.etcd, s.ipamUpdateHandler)
-	// sync IPAM and call ipamUpdateHandler
-	s.t.Go(func() error { return fmt.Errorf("syncIPAM: %s", s.ipam.sync()) })
+	if s.datastore == calicoapi.EtcdV2 {
+		s.ipam = newIPAMCache(s.etcd, s.ipamUpdateHandler)
+		// sync IPAM and call ipamUpdateHandler
+		s.t.Go(func() error { return fmt.Errorf("syncIPAM: %s", s.ipam.sync()) })
+		// watch prefix assigned and announce to other BGP peers
+		s.t.Go(func() error { return fmt.Errorf("watchPrefix: %s", s.watchPrefix()) })
+		// watch BGP configuration
+		s.t.Go(func() error { return fmt.Errorf("watchBGPConfig: %s", s.watchBGPConfig()) })
+	} else if s.datastore == calicoapi.Kubernetes {
+		s.t.Go(func() error { return fmt.Errorf("k8s interval loop: %s", s.process.IntervalLoop()) })
+	}
 	// watch routes from other BGP peers and update FIB
 	s.t.Go(func() error { return fmt.Errorf("watchBGPPath: %s", s.watchBGPPath()) })
-	// watch prefix assigned and announce to other BGP peers
-	s.t.Go(func() error { return fmt.Errorf("watchPrefix: %s", s.watchPrefix()) })
-	// watch BGP configuration
-	s.t.Go(func() error { return fmt.Errorf("watchBGPConfig: %s", s.watchBGPConfig()) })
+
 	// watch routes added by kernel and announce to other BGP peers
 	s.t.Go(func() error { return fmt.Errorf("watchKernelRoute: %s", s.watchKernelRoute()) })
 
@@ -401,12 +447,12 @@ func (s *Server) getMeshNeighborConfigs() ([]*bgpconfig.Neighbor, error) {
 }
 
 // getNeighborConfigFromPeer returns a BGP neighbor configuration struct from *etcd.Node
-func getNeighborConfigFromPeer(node *etcd.Node, neighborType string) (*bgpconfig.Neighbor, error) {
+func getNeighborConfigFromPeer(peer string, neighborType string) (*bgpconfig.Neighbor, error) {
 	m := &struct {
 		IP  string `json:"ip"`
 		ASN string `json:"as_num"`
 	}{}
-	if err := json.Unmarshal([]byte(node.Value), m); err != nil {
+	if err := json.Unmarshal([]byte(peer), m); err != nil {
 		return nil, err
 	}
 	asn, err := numorstring.ASNumberFromString(m.ASN)
@@ -539,7 +585,7 @@ func (s *Server) getAssignedPrefixes(api etcd.KeysAPI) ([]*bgptable.Path, uint64
 			return err
 		}
 		if index == 0 {
-		        index = res.Index
+			index = res.Index
 		}
 		for _, v := range res.Node.Nodes {
 			path, err := s.makePath(etcdKeyToPrefix(v.Key), false)
@@ -651,13 +697,13 @@ func (s *Server) watchBGPConfig() error {
 		handleNonMeshNeighbor := func(neighborType string) error {
 			switch res.Action {
 			case "delete":
-				n, err := getNeighborConfigFromPeer(res.PrevNode, neighborType)
+				n, err := getNeighborConfigFromPeer(res.PrevNode.Value, neighborType)
 				if err != nil {
 					return err
 				}
 				return s.bgpServer.DeleteNeighbor(n)
 			case "set", "create", "update", "compareAndSwap":
-				n, err := getNeighborConfigFromPeer(res.Node, neighborType)
+				n, err := getNeighborConfigFromPeer(res.Node.Value, neighborType)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
## Description

This supports kubernetes datastore backend.
We should refactor calico-bgp-daemon generally when libcalico-go
is organized.
This also bumps libcalico-go to v1.6.1 and adds k8s.io/client-go.

Fixes #29

## Todos
- [ ] Tests
- [ ] Documentation

## Release Note

```release-note
Added support for using the Kubernetes API datastore in GoBGP
```