### PR TITLE
Adding support for ppc64le.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.4
 
 MAINTAINER Gunjan Patel <gunjan@tigera.io>
 
-ADD dist/gobgp /gobgp
-ADD dist/calico-bgp-daemon /calico-bgp-daemon
+ADD dist/amd64/gobgp /gobgp
+ADD dist/amd64/calico-bgp-daemon /calico-bgp-daemon
 
 ENTRYPOINT ["/calico-bgp-daemon"]

--- a/Dockerfile-ppc64le
+++ b/Dockerfile-ppc64le
@@ -1,0 +1,8 @@
+FROM ppc64le/alpine:3.6
+
+MAINTAINER Gunjan Patel <gunjan@tigera.io>
+
+ADD dist/ppc64le/gobgp /gobgp
+ADD dist/ppc64le/calico-bgp-daemon /calico-bgp-daemon
+
+ENTRYPOINT ["/calico-bgp-daemon"]

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,23 @@
+###############################################################################
+# The build architecture is select by setting the ARCH variable.
+# For example: When building on ppc64le you could use ARCH=ppc64le make <....>.
+# When ARCH is undefined it defaults to amd64.
+ARCH?=amd64
+ifeq ($(ARCH),amd64)
+        ARCHTAG?=
+endif
 
-CALICO_BUILD?=calico/go-build
+ifeq ($(ARCH),ppc64le)
+        ARCHTAG:=-ppc64le
+endif
+
+CALICO_BUILD?=calico/go-build$(ARCHTAG)
 SRC_FILES=$(shell find . -type f -name '*.go')
 GOBGPD_VERSION?=$(shell git describe --tags --dirty)
-CONTAINER_NAME?=calico/gobgpd
+CONTAINER_NAME?=calico/gobgpd$(ARCHTAG)
 PACKAGE_NAME?=github.com/projectcalico/calico-bgp-daemon
 LOCAL_USER_ID?=$(shell id -u $$USER)
+DIST=dist/$(ARCH)
 
 # Use this to populate the vendor directory after checking out the repository.
 # To update upstream dependencies, delete the glide.lock file first.
@@ -19,31 +32,33 @@ vendor: glide.yaml
 		  cd /go/src/$(PACKAGE_NAME) && \
       glide install -strip-vendor'
 
-binary: dist/calico-bgp-daemon
+binary: $(DIST)/calico-bgp-daemon
 
-dist/gobgp:
+$(DIST)/gobgp:
 	mkdir -p $(@D)
-	docker run --rm -v $(CURDIR)/dist:/go/bin \
+	docker run --rm -v $(CURDIR)/$(DIST):/go/bin \
 	-e LOCAL_USER_ID=$(LOCAL_USER_ID) \
+	-e ARCH=$(ARCH) \
 	$(CALICO_BUILD) go get -v github.com/osrg/gobgp/gobgp
 
-dist/calico-bgp-daemon: $(SRC_FILES) vendor
+$(DIST)/calico-bgp-daemon: $(SRC_FILES) vendor
 	mkdir -p $(@D)
-	go build -v -o dist/calico-bgp-daemon \
+	go build -v -o $(DIST)/calico-bgp-daemon \
 	-ldflags "-X main.VERSION=$(GOBGPD_VERSION) -s -w" main.go ipam.go k8s.go
 
-build-containerized: clean vendor dist/gobgp
-	mkdir -p dist
+build-containerized: clean vendor $(DIST)/gobgp
+	mkdir -p $(DIST)
 	docker run --rm \
 	-v $(CURDIR):/go/src/$(PACKAGE_NAME) \
-	-v $(CURDIR)/dist:/go/src/$(PACKAGE_NAME)/dist \
+	-v $(CURDIR)/$(DIST):/go/src/$(PACKAGE_NAME)/$(DIST) \
 	-e LOCAL_USER_ID=$(LOCAL_USER_ID) \
+	-e ARCH=$(ARCH) \
 		$(CALICO_BUILD) sh -c '\
 			cd /go/src/$(PACKAGE_NAME) && \
 			make binary'
 
 $(CONTAINER_NAME): build-containerized
-	docker build -t $(CONTAINER_NAME) .
+	docker build -t $(CONTAINER_NAME) -f Dockerfile$(ARCHTAG) .
 
 release: clean
 ifndef VERSION
@@ -54,18 +69,18 @@ endif
 	# Check that the version output appears on a line of its own (the -x option to grep).
 	# Tests that the "git tag" makes it into the binary. Main point is to catch "-dirty" builds
 	@echo "Checking if the tag made it into the binary"
-	docker run --rm calico/gobgpd -v | grep -x $(VERSION) || (echo "Reported version:" `docker run --rm calico/gobgpd -v` "\nExpected version: $(VERSION)" && exit 1)
-	docker tag calico/gobgpd calico/gobgpd:$(VERSION)
-	docker tag calico/gobgpd quay.io/calico/gobgpd:$(VERSION)
-	docker tag calico/gobgpd quay.io/calico/gobgpd:latest
+	docker run --rm $(CONTAINER_NAME) -v | grep -x $(VERSION) || (echo "Reported version:" `docker run --rm $(CONTAINER_NAME) -v` "\nExpected version: $(VERSION)" && exit 1)
+	docker tag $(CONTAINER_NAME) $(CONTAINER_NAME):$(VERSION)
+	docker tag $(CONTAINER_NAME) quay.io/$(CONTAINER_NAME):$(VERSION)
+	docker tag $(CONTAINER_NAME) quay.io/$(CONTAINER_NAME):latest
 
-	@echo "Now push the tag and images. Then create a release on Github and attach the dist/gobgpd and dist/gobgp binaries"
+	@echo "Now push the tag and images. Then create a release on Github and attach the $(DIST)/gobgpd and $(DIST)/gobgp binaries"
 	@echo "git push origin $(VERSION)"
-	@echo "docker push calico/gobgpd:$(VERSION)"
-	@echo "docker push quay.io/calico/gobgpd:$(VERSION)"
-	@echo "docker push calico/gobgpd:latest"
-	@echo "docker push quay.io/calico/gobgpd:latest"
+	@echo "docker push $(CONTAINER_NAME):$(VERSION)"
+	@echo "docker push quay.io/$(CONTAINER_NAME):$(VERSION)"
+	@echo "docker push $(CONTAINER_NAME):latest"
+	@echo "docker push quay.io/$(CONTAINER_NAME):latest"
 
 clean:
 	rm -rf vendor
-	rm -rf dist
+	rm -rf $(DIST)


### PR DESCRIPTION
Signed-off-by: David Wilder <wilder@us.ibm.com>

## Description
This adds multi-arch support and ppc64le support to the build.

Summery of the changes:

- Build with ARCH=ppc64le make <...>
- If ARCH is undefined it defaults to amd64.
- The dist directory is now architecture specific, dist/$(ARCH).
- The created docker image name is appended with -($ARCH) except for amd64 where the name is unchanged.

## Todos
- [ ] Tests
- [ ] Documentation
