### PR TITLE
Fix build error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,12 @@ $(DIST)/gobgp:
 	docker run --rm -v $(CURDIR)/$(DIST):/go/bin \
 	-e LOCAL_USER_ID=$(LOCAL_USER_ID) \
 	-e ARCH=$(ARCH) \
-	$(CALICO_BUILD) go get -v github.com/osrg/gobgp/gobgp
+	$(CALICO_BUILD) sh -c '\
+		go get -u github.com/golang/dep/cmd/dep && \
+		go get github.com/osrg/gobgp || \
+		cd /go/src/github.com/osrg/gobgp && dep ensure && \
+		go get -v github.com/osrg/gobgp/gobgp'
+	rm -f $(DIST)/dep
 
 $(DIST)/calico-bgp-daemon: $(SRC_FILES) vendor
 	mkdir -p $(@D)


### PR DESCRIPTION
"go get" for osrg/gobgp master fails. This fixes it.

Signed-off-by: fumihiko kakuma <kakuma@valinux.co.jp>

## Description
"go get" for gobgp master fails as api of github.com/satori/go.uuid was changed.

We can find the result of build from the following:
https://semaphoreci.com/calico/calico-bgp-daemon/branches/master/builds/433

## Todos
build of calico-bgp-daemon

## Release Note
