### PR TITLE
Fix RouteReplace error with ipip mode change

### DIFF
--- a/main.go
+++ b/main.go
@@ -138,6 +138,7 @@ func recursiveNexthopLookup(bgpNexthop net.IP) (net.IP, error) {
 }
 
 func cleanUpRoutes() error {
+	log.Println("Clean up injected routes")
 	filter := &netlink.Route{
 		Protocol: RTPROT_GOBGP,
 	}
@@ -352,6 +353,15 @@ func (s *Server) ipamUpdateHandler(pool *ipPool) error {
 				}
 				route.Gw = gw
 				route.Flags = 0
+				rs, err := netlink.RouteGet(gw)
+				if err != nil {
+					return err
+				}
+				if len(rs) == 0 {
+					return fmt.Errorf("no route for path: %s", gw)
+				}
+				r := rs[0]
+				route.LinkIndex = r.LinkIndex
 			}
 			return netlink.RouteReplace(&route)
 		}


### PR DESCRIPTION
## Description
calico-bgp-daemon restarts by RouteReplace error, when ipip mode
changed from always to cross-subnet.
We will not notice this behavior as restart resolves the error.
The error occurs because a LinkIndex in route struct is set index
of tunl0. This PR sets the correct value to the LinkIndex.
The above error is different from failure of ST said in #37.

## Todos
- [ ] Tests
I have done a simple test.

## Release Note