### PR TITLE
cross-compile and push images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
-
+dist/
 .idea/
 .editorconfig
-gobgp
-calico-bgp-daemon
 vendor/
-
-
+gobgp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,1 @@
-FROM alpine:3.4
-
-MAINTAINER Gunjan Patel <gunjan@tigera.io>
-
-ADD dist/amd64/gobgp /gobgp
-ADD dist/amd64/calico-bgp-daemon /calico-bgp-daemon
-
-ENTRYPOINT ["/calico-bgp-daemon"]
+Dockerfile.amd64

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,0 +1,8 @@
+FROM amd64/alpine:3.7
+
+MAINTAINER Gunjan Patel <gunjan@tigera.io>
+
+ADD dist/amd64/gobgp /gobgp
+ADD dist/amd64/calico-bgp-daemon /calico-bgp-daemon
+
+ENTRYPOINT ["/calico-bgp-daemon"]

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,8 @@
+FROM arm64v8/alpine:3.7
+
+MAINTAINER Gunjan Patel <gunjan@tigera.io>
+
+ADD dist/arm64/gobgp /gobgp
+ADD dist/arm64/calico-bgp-daemon /calico-bgp-daemon
+
+ENTRYPOINT ["/calico-bgp-daemon"]

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,4 +1,4 @@
-FROM ppc64le/alpine:3.6
+FROM ppc64le/alpine:3.7
 
 MAINTAINER Gunjan Patel <gunjan@tigera.io>
 

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -1,0 +1,8 @@
+FROM s390x/alpine:3.7
+
+MAINTAINER Gunjan Patel <gunjan@tigera.io>
+
+ADD dist/s390x/gobgp /gobgp
+ADD dist/s390x/calico-bgp-daemon /calico-bgp-daemon
+
+ENTRYPOINT ["/calico-bgp-daemon"]

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,47 @@
 ###############################################################################
-# The build architecture is select by setting the ARCH variable.
-# For example: When building on ppc64le you could use ARCH=ppc64le make <....>.
-# When ARCH is undefined it defaults to amd64.
-ARCH?=amd64
-ifeq ($(ARCH),amd64)
-        ARCHTAG?=
-        GO_BUILD_VER?=v0.12
+# Both native and cross architecture builds are supported.
+# The target architecture is select by setting the ARCH variable.
+# When ARCH is undefined it is set to the detected host architecture.
+# When ARCH differs from the host architecture a crossbuild will be performed.
+ARCHES=amd64 arm64 ppc64le s390x
+
+# BUILDARCH is the host architecture
+# ARCH is the target architecture
+# we need to keep track of them separately
+BUILDARCH ?= $(shell uname -m)
+
+# canonicalized names for host architecture
+ifeq ($(BUILDARCH),aarch64)
+        BUILDARCH=arm64
+endif
+ifeq ($(BUILDARCH),x86_64)
+        BUILDARCH=amd64
 endif
 
-ifeq ($(ARCH),ppc64le)
-        ARCHTAG:=-ppc64le
-        GO_BUILD_VER?=latest
+# unless otherwise set, I am building for my own architecture, i.e. not cross-compiling
+ARCH ?= $(BUILDARCH)
+
+# canonicalized names for target architecture
+ifeq ($(ARCH),aarch64)
+        override ARCH=arm64
+endif
+ifeq ($(ARCH),x86_64)
+    override ARCH=amd64
 endif
 
-CALICO_BUILD?=calico/go-build$(ARCHTAG):$(GO_BUILD_VER)
+GO_BUILD_VER ?= v0.15
+
+
+
+CALICO_BUILD?=calico/go-build:$(GO_BUILD_VER)
 SRC_FILES=$(shell find . -type f -name '*.go')
 GOBGPD_VERSION?=$(shell git describe --tags --dirty)
-CONTAINER_NAME?=calico/gobgpd$(ARCHTAG)
+CONTAINER_NAME?=calico/gobgpd
 PACKAGE_NAME?=github.com/projectcalico/calico-bgp-daemon
 LOCAL_USER_ID?=$(shell id -u $$USER)
 DIST=dist/$(ARCH)
+
+.PHONY: all image image-all build binary build-containerized
 
 # Use this to populate the vendor directory after checking out the repository.
 # To update upstream dependencies, delete the glide.lock file first.
@@ -34,21 +56,44 @@ vendor: glide.yaml
 		  cd /go/src/$(PACKAGE_NAME) && \
       glide install -strip-vendor'
 
+.PHONY: build-all
+build-all: $(addprefix sub-build-,$(ARCHES))
+sub-build-%:
+	$(MAKE) build ARCH=$*
+
+build: build-containerized
 binary: $(DIST)/calico-bgp-daemon
 
-$(DIST)/gobgp:
+# instead of 'go get', run `git clone` and then `dep ensure && go build` so the files are cached
+gobgp:
+	git clone https://github.com/osrg/gobgp gobgp
+
+gobgp/vendor:
+	docker run --rm \
+		-v $(CURDIR)/gobgp:/go/src/github.com/osrg/gobgp \
+		-w /go/src/github.com/osrg/gobgp \
+		-e LOCAL_USER_ID=$(LOCAL_USER_ID) \
+		-e ARCH=$(ARCH) \
+		-e GOARCH=$(ARCH) \
+		$(CALICO_BUILD) dep ensure
+
+$(DIST)/gobgp: gobgp gobgp/vendor
 	mkdir -p $(@D)
-	docker run --rm -v $(CURDIR)/$(DIST):/go/bin \
-	-e LOCAL_USER_ID=$(LOCAL_USER_ID) \
-	-e ARCH=$(ARCH) \
-	$(CALICO_BUILD) go get -v github.com/osrg/gobgp/gobgp
+	docker run --rm \
+		-v $(CURDIR)/gobgp:/go/src/github.com/osrg/gobgp \
+		-v $(CURDIR)/$(DIST):/outbin \
+		-w /go/src/github.com/osrg/gobgp \
+		-e LOCAL_USER_ID=$(LOCAL_USER_ID) \
+		-e ARCH=$(ARCH) \
+		-e GOARCH=$(ARCH) \
+		$(CALICO_BUILD) go build -v -o /outbin/gobgp github.com/osrg/gobgp/gobgp
 
 $(DIST)/calico-bgp-daemon: $(SRC_FILES) vendor
 	mkdir -p $(@D)
-	go build -v -o $(DIST)/calico-bgp-daemon \
+	GOARCH=$(ARCH) go build -v -o $(DIST)/calico-bgp-daemon \
 	-ldflags "-X main.VERSION=$(GOBGPD_VERSION) -s -w" main.go ipam.go k8s.go
 
-build-containerized: clean vendor $(DIST)/gobgp
+build-containerized: vendor $(DIST)/gobgp
 	mkdir -p $(DIST)
 	docker run --rm \
 	-v $(CURDIR):/go/src/$(PACKAGE_NAME) \
@@ -59,30 +104,78 @@ build-containerized: clean vendor $(DIST)/gobgp
 			cd /go/src/$(PACKAGE_NAME) && \
 			make binary'
 
+image-all: $(addprefix sub-image-,$(ARCHES))
+sub-image-%:
+	$(MAKE) image ARCH=$*
+
+
+image: $(CONTAINER_NAME)
 $(CONTAINER_NAME): build-containerized
-	docker build -t $(CONTAINER_NAME) -f Dockerfile$(ARCHTAG) .
+	docker build -t $(CONTAINER_NAME):latest-$(ARCH) -f Dockerfile.$(ARCH) .
+
+
+###############################################################################
+# tag and push images of any tag
+###############################################################################
+
+# ensure we have a real imagetag
+imagetag:
+ifndef IMAGETAG
+	$(error IMAGETAG is undefined - run using make <target> IMAGETAG=X.Y.Z)
+endif
+
+## push one arch
+push: imagetag
+	docker push $(CONTAINER_NAME):$(IMAGETAG)-$(ARCH)
+	docker push quay.io/$(CONTAINER_NAME):$(IMAGETAG)-$(ARCH)
+ifeq ($(ARCH),amd64)
+	docker push $(CONTAINER_NAME):$(IMAGETAG)
+	docker push quay.io/$(CONTAINER_NAME):$(IMAGETAG)
+endif
+
+push-all: imagetag $(addprefix sub-push-,$(ARCHES))
+sub-push-%:
+	$(MAKE) push ARCH=$* IMAGETAG=$(IMAGETAG)
+
+## tag images of one arch
+tag-images: imagetag
+	docker tag $(CONTAINER_NAME):latest-$(ARCH) $(CONTAINER_NAME):$(IMAGETAG)-$(ARCH)
+	docker tag $(CONTAINER_NAME):latest-$(ARCH) quay.io/$(CONTAINER_NAME):$(IMAGETAG)-$(ARCH)
+ifeq ($(ARCH),amd64)
+	docker tag $(CONTAINER_NAME):latest-$(ARCH) $(CONTAINER_NAME):$(IMAGETAG)
+	docker tag $(CONTAINER_NAME):latest-$(ARCH) quay.io/$(CONTAINER_NAME):$(IMAGETAG)
+endif
+
+## tag images of all archs
+tag-images-all: imagetag $(addprefix sub-tag-images-,$(ARCHES))
+sub-tag-images-%:
+	$(MAKE) tag-images ARCH=$* IMAGETAG=$(IMAGETAG)
+
+
+###############################################################################
+# cut versioned releases
+###############################################################################
 
 release: clean
 ifndef VERSION
 	$(error VERSION is undefined - run using make release VERSION=vX.Y.Z)
 endif
 	git tag $(VERSION)
-	$(MAKE) $(CONTAINER_NAME) 
+	$(MAKE) $(CONTAINER_NAME)
 	# Check that the version output appears on a line of its own (the -x option to grep).
 	# Tests that the "git tag" makes it into the binary. Main point is to catch "-dirty" builds
 	@echo "Checking if the tag made it into the binary"
-	docker run --rm $(CONTAINER_NAME) -v | grep -x $(VERSION) || (echo "Reported version:" `docker run --rm $(CONTAINER_NAME) -v` "\nExpected version: $(VERSION)" && exit 1)
-	docker tag $(CONTAINER_NAME) $(CONTAINER_NAME):$(VERSION)
-	docker tag $(CONTAINER_NAME) quay.io/$(CONTAINER_NAME):$(VERSION)
-	docker tag $(CONTAINER_NAME) quay.io/$(CONTAINER_NAME):latest
+	docker run --rm $(CONTAINER_NAME):latest-$(ARCH) -v | grep -x $(VERSION) || (echo "Reported version:" `docker run --rm $(CONTAINER_NAME):latest-$(ARCH) -v` "\nExpected version: $(VERSION)" && exit 1)
 
-	@echo "Now push the tag and images. Then create a release on Github and attach the $(DIST)/gobgpd and $(DIST)/gobgp binaries"
+	$(MAKE) tag IMAGETAG=$(VERSION) ARCH=$(ARCH)
+	$(MAKE) tag IMAGETAG=latest ARCH=$(ARCH)
+	$(MAKE) push IMAGETAG=$(VERSION) ARCH=$(ARCH)
+	$(MAKE) push IMAGETAG=latest ARCH=$(ARCH)
+
+	@echo "Now create a release on Github and attach the $(DIST)/gobgpd and $(DIST)/gobgp binaries"
 	@echo "git push origin $(VERSION)"
-	@echo "docker push $(CONTAINER_NAME):$(VERSION)"
-	@echo "docker push quay.io/$(CONTAINER_NAME):$(VERSION)"
-	@echo "docker push $(CONTAINER_NAME):latest"
-	@echo "docker push quay.io/$(CONTAINER_NAME):latest"
 
 clean:
 	rm -rf vendor
+	rm -rf gobgp
 	rm -rf $(DIST)


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Adds the following:

* cross-compile support from `amd64` to all supported arches
* standard Makefile targets `build` and `image` which support `ARCH`
* standard Makefile target `image-all` to create all supported arches
* standard Makefile target `push` to push out a given `IMAGETAG` for an individual `ARCH`
* standard Makefile target `push-all` to push out a given `IMAGETAG` for all supported arches
* standardizes the `Dockerfile`s

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Standard support for cross-compile build, image and push for all supported arches
```