### PR TITLE
Replicate all semaphore activities in ci and cd targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,22 @@ PACKAGE_NAME?=github.com/projectcalico/calico-bgp-daemon
 LOCAL_USER_ID?=$(shell id -u $$USER)
 DIST=dist/$(ARCH)
 
-.PHONY: all image image-all build binary build-containerized
+.PHONY: all image image-all build binary build-containerized ci cd
+
+## Builds the code and runs all tests.
+ci: image
+
+## Deploys images to registry
+cd:
+ifndef CONFIRM
+	$(error CONFIRM is undefined - run using make <target> CONFIRM=true)
+endif
+ifndef BRANCH_NAME
+	$(error BRANCH_NAME is undefined - run using make <target> BRANCH_NAME=var or set an environment variable)
+endif
+	$(MAKE) tag-images push IMAGETAG=${BRANCH_NAME}
+	$(MAKE) tag-images push IMAGETAG=$(shell git describe --tags --dirty --always --long)
+
 
 # Use this to populate the vendor directory after checking out the repository.
 # To update upstream dependencies, delete the glide.lock file first.


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Replicate the workflow from kube-controllers PR here:

* Create a `make ci` target that does everything in the various semaphore jobs except tag images and push to registries
* Create a `make cd` target that only tags images and pushes to registries

Should update Semaphore after merged.

As discussed with @caseydavenport @fasaxc @tomdee

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```